### PR TITLE
adds options object and passes it PNP's resolveRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ module.exports = {
 };
 ```
 
+You can also pass options to be forwarded to PNP's resolveRequest
+
+```js
+const resolve = require(`rollup-plugin-pnp-resolve`);
+
+module.exports = {
+  plugins: [
+    resolve({extensions: ['.jsx', '.js']}),
+  ],
+};
+```
+
+
 ## License (MIT)
 
 > **Copyright © 2016 Maël Nison**

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ try {
   // not in PnP; not a problem
 }
 
-module.exports = () => ({
+module.exports = (options) => ({
   name: `pnp`,
   resolveId: (importee, importer) => {
     if (!pnp) {
@@ -21,6 +21,6 @@ module.exports = () => ({
       return;
     }
 
-    return pnp.resolveRequest(importee, importer);
+    return pnp.resolveRequest(importee, importer, options);
   },
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name":"rollup-plugin-pnp-resolve",
-    "version":"1.0.1",
+    "name": "rollup-plugin-pnp-resolve",
+    "version": "1.0.1",
     "description": "plug'n'play resolver for Rollup",
     "license": "MIT",
     "engines": {


### PR DESCRIPTION
Sometimes when using files with .jsx resolve can't find them with the default configurations.

this PR allows to pass an object to include such options