### PR TITLE
Allow the mainFields option

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,8 +55,8 @@ module.exports = (options) => {
         return;
       }
       
-      const location = pnp.resolveToUnqualified(request, issuer, {
-        extensions: resolverOptions.extensions,
+      const location = pnp.resolveToUnqualified(importee, importer, {
+        extensions: options.extensions,
       });
       /* 
        * intuitevly packageInformation points to @material-ui/core's package.json

--- a/index.js
+++ b/index.js
@@ -1,46 +1,56 @@
 let pnp;
-
+const fs = require("fs");
+const path = require("path");
 try {
   pnp = require(`pnpapi`);
 } catch (error) {
   // not in PnP; not a problem
 }
 
-function getMainFields (options) {
-	let mainFields;
-	if (options.mainFields) {
-		if ('module' in options || 'main' in options || 'jsnext' in options) {
-			throw new Error(`node-resolve: do not use deprecated 'module', 'main', 'jsnext' options with 'mainFields'`);
-		}
-		mainFields = options.mainFields;
-	} else {
-		mainFields = [];
-		[['module', 'module', true], ['jsnext', 'jsnext:main', false], ['main', 'main', true]].forEach(([option, field, defaultIncluded]) => {
-			if (option in options) {
-				// eslint-disable-next-line no-console
-				console.warn(`node-resolve: setting options.${option} is deprecated, please override options.mainFields instead`);
-				if (options[option]) {
-					mainFields.push(field);
-				}
-			} else if (defaultIncluded) {
-				mainFields.push(field);
-			}
-		});
-	}
-	if (options.browser && mainFields.indexOf('browser') === -1) {
-		return ['browser'].concat(mainFields);
-	}
-	if ( !mainFields.length ) {
-		throw new Error( `Please ensure at least one 'mainFields' value is specified` );
-	}
-	return mainFields;
+function getMainFields(options) {
+  let mainFields;
+  if (options.mainFields) {
+    if ("module" in options || "main" in options || "jsnext" in options) {
+      throw new Error(
+        `node-resolve: do not use deprecated 'module', 'main', 'jsnext' options with 'mainFields'`
+      );
+    }
+    mainFields = options.mainFields;
+  } else {
+    mainFields = [];
+    [
+      ["module", "module", true],
+      ["jsnext", "jsnext:main", false],
+      ["main", "main", true]
+    ].forEach(([option, field, defaultIncluded]) => {
+      if (option in options) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `node-resolve: setting options.${option} is deprecated, please override options.mainFields instead`
+        );
+        if (options[option]) {
+          mainFields.push(field);
+        }
+      } else if (defaultIncluded) {
+        mainFields.push(field);
+      }
+    });
+  }
+  if (options.browser && mainFields.indexOf("browser") === -1) {
+    return ["browser"].concat(mainFields);
+  }
+  if (!mainFields.length) {
+    throw new Error(
+      `Please ensure at least one 'mainFields' value is specified`
+    );
+  }
+  return mainFields;
 }
 
-module.exports = (options) => {
-
+module.exports = options => {
   const mainFields = getMainFields(options);
 
-  return ({
+  return {
     name: `pnp`,
     resolveId: (importee, importer) => {
       if (!pnp) {
@@ -54,35 +64,31 @@ module.exports = (options) => {
       if (!importer) {
         return;
       }
-      
+
       const location = pnp.resolveToUnqualified(importee, importer, {
-        extensions: options.extensions,
+        extensions: options.extensions
       });
-      /* 
-       * intuitevly packageInformation points to @material-ui/core's package.json
-       * but it returns the workspace root 
-      const locator = pnp.findPackageLocator(location);
-      const packageInformation = pnp.getPackageInformation(locator); */
-      const packageJson = JSON.parse(fs.readFileSync(
-        path.resolve(location, './package.json'),
-      ));
-      
+
+      const packageJson = JSON.parse(
+        fs.readFileSync(path.resolve(location, "./package.json"))
+      );
+
       // Guess which main field to use
       let overriddenMain = false;
       let overridenMainField = null;
-      for ( let i = 0; i < mainFields.length; i++ ) {
+      for (let i = 0; i < mainFields.length; i++) {
         const field = mainFields[i];
-        if ( typeof packageJson[ field ] === 'string' ) {
-          overridenMainField = packageJson[ field ]
-				  overriddenMain = true;
-				  break;
-			  }
-		  }
-      const mainField = overriddenMain ? overridenMainField : "main"
-      
-      const resolution = path.resolve(location, packageJson[mainField]);
+        if (typeof packageJson[field] === "string") {
+          overridenMainField = packageJson[field];
+          overriddenMain = true;
+          break;
+        }
+      }
+      const mainField = overriddenMain ? overridenMainField : "main";
+
+      const resolution = path.resolve(location, mainField);
       return resolution;
       //return pnp.resolveRequest(importee, importer, options);
     }
-  })
+  };
 };

--- a/index.js
+++ b/index.js
@@ -63,9 +63,9 @@ module.exports = (options) => {
        * but it returns the workspace root 
       const locator = pnp.findPackageLocator(location);
       const packageInformation = pnp.getPackageInformation(locator); */
-      const packageJson = fse.readJsonSync(
+      const packageJson = JSON.parse(fs.readFileSync(
         path.resolve(location, './package.json'),
-      );
+      ));
       
       // Guess which main field to use
       let overriddenMain = false;

--- a/index.js
+++ b/index.js
@@ -6,21 +6,83 @@ try {
   // not in PnP; not a problem
 }
 
-module.exports = (options) => ({
-  name: `pnp`,
-  resolveId: (importee, importer) => {
-    if (!pnp) {
-      return;
-    }
+function getMainFields (options) {
+	let mainFields;
+	if (options.mainFields) {
+		if ('module' in options || 'main' in options || 'jsnext' in options) {
+			throw new Error(`node-resolve: do not use deprecated 'module', 'main', 'jsnext' options with 'mainFields'`);
+		}
+		mainFields = options.mainFields;
+	} else {
+		mainFields = [];
+		[['module', 'module', true], ['jsnext', 'jsnext:main', false], ['main', 'main', true]].forEach(([option, field, defaultIncluded]) => {
+			if (option in options) {
+				// eslint-disable-next-line no-console
+				console.warn(`node-resolve: setting options.${option} is deprecated, please override options.mainFields instead`);
+				if (options[option]) {
+					mainFields.push(field);
+				}
+			} else if (defaultIncluded) {
+				mainFields.push(field);
+			}
+		});
+	}
+	if (options.browser && mainFields.indexOf('browser') === -1) {
+		return ['browser'].concat(mainFields);
+	}
+	if ( !mainFields.length ) {
+		throw new Error( `Please ensure at least one 'mainFields' value is specified` );
+	}
+	return mainFields;
+}
 
-    if (/\0/.test(importee)) {
-      return null;
-    }
+module.exports = (options) => {
 
-    if (!importer) {
-      return;
-    }
+  const mainFields = getMainFields(options);
 
-    return pnp.resolveRequest(importee, importer, options);
-  },
-});
+  return ({
+    name: `pnp`,
+    resolveId: (importee, importer) => {
+      if (!pnp) {
+        return;
+      }
+
+      if (/\0/.test(importee)) {
+        return null;
+      }
+
+      if (!importer) {
+        return;
+      }
+      
+      const location = pnp.resolveToUnqualified(request, issuer, {
+        extensions: resolverOptions.extensions,
+      });
+      /* 
+       * intuitevly packageInformation points to @material-ui/core's package.json
+       * but it returns the workspace root 
+      const locator = pnp.findPackageLocator(location);
+      const packageInformation = pnp.getPackageInformation(locator); */
+      const packageJson = fse.readJsonSync(
+        path.resolve(location, './package.json'),
+      );
+      
+      // Guess which main field to use
+      let overriddenMain = false;
+      let overridenMainField = null;
+      for ( let i = 0; i < mainFields.length; i++ ) {
+        const field = mainFields[i];
+        if ( typeof packageJson[ field ] === 'string' ) {
+          overridenMainField = packageJson[ field ]
+				  overriddenMain = true;
+				  break;
+			  }
+		  }
+      const mainField = overriddenMain ? overridenMainField : "main"
+      
+      const resolution = path.resolve(location, packageJson[mainField]);
+      return resolution;
+      //return pnp.resolveRequest(importee, importer, options);
+    }
+  })
+};

--- a/index.js
+++ b/index.js
@@ -65,30 +65,41 @@ module.exports = options => {
         return;
       }
 
-      const location = pnp.resolveToUnqualified(importee, importer, {
-        extensions: options.extensions
-      });
+      try {
+        const location = pnp.resolveToUnqualified(importee, importer, {
+          extensions: options.extensions
+        });
 
-      const packageJson = JSON.parse(
-        fs.readFileSync(path.resolve(location, "./package.json"))
-      );
+        const packageJson = JSON.parse(
+          fs.readFileSync(path.resolve(location, "./package.json"))
+        );
 
-      // Guess which main field to use
-      let overriddenMain = false;
-      let overridenMainField = null;
-      for (let i = 0; i < mainFields.length; i++) {
-        const field = mainFields[i];
-        if (typeof packageJson[field] === "string") {
-          overridenMainField = packageJson[field];
-          overriddenMain = true;
-          break;
+        // Guess which main field to use
+        let overriddenMain = false;
+        let overridenMainField = null;
+        for (let i = 0; i < mainFields.length; i++) {
+          const field = mainFields[i];
+          if (typeof packageJson[field] === "string") {
+            overridenMainField = packageJson[field];
+            overriddenMain = true;
+            break;
+          }
         }
-      }
-      const mainField = overriddenMain ? overridenMainField : "main";
+        const mainField = overriddenMain ? overridenMainField : "main";
 
-      const resolution = path.resolve(location, mainField);
-      return resolution;
-      //return pnp.resolveRequest(importee, importer, options);
+        const resolution = path.resolve(location, mainField);
+        return resolution;
+        //return pnp.resolveRequest(importee, importer, options);
+      } catch (e) {
+        throw "From " +
+          importer +
+          ", could not import " +
+          importee +
+          " located at " +
+          pnp.resolveToUnqualified(importee, importer, {
+            extensions: options.extensions
+          });
+      }
     }
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rollup-plugin-pnp-resolve",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "plug'n'play resolver for Rollup",
     "license": "MIT",
     "engines": {


### PR DESCRIPTION
Allow to use things like `mainFields: ['module', 'main']` in options

See issue: https://github.com/arcanis/rollup-plugin-pnp-resolve/issues/2