### PR TITLE
breaking: resolve to unqualified

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,11 @@ try {
   // not in PnP; not a problem
 }
 
+const path = require("path");
+
 module.exports = (options) => ({
   name: `pnp`,
-  resolveId: (importee, importer) => {
+  resolveId: function (importee, importer) {
     if (!pnp) {
       return;
     }
@@ -17,10 +19,20 @@ module.exports = (options) => ({
       return null;
     }
 
+    if (path.isAbsolute(importee)) {
+      return null;
+    }
+
     if (!importer) {
       return;
     }
 
-    return pnp.resolveRequest(importee, importer, options);
+    const resolved = pnp.resolveToUnqualified(importee, importer, options);
+
+    if (!resolved) {
+      return null;
+    }
+
+    return this.resolve(resolved, importer);
   },
 });


### PR DESCRIPTION
This PR implements https://github.com/arcanis/rollup-plugin-pnp-resolve/pull/4#issuecomment-543962428 and has been tested on babel repo: https://github.com/JLHwung/babel/commit/774959f0877c17aa9dcd5221385103825b293b7e

Our case is to use this plugin alongside with `@rollup/plugin-node-resolve` so we can still use `browsers`, `mainFields`, etc. implemented in `@rollup/plugin-node-resolve`.

e.g.
```js
const nodeResolve = require(`@rollup/plugin-node-resolve`);
const pnpResolve = require(`rollup-plugin-pnp-resolve`);

module.exports = {
  plugins: [
    pnpResolve(),
    nodeResolve({
        mainFields: ["jsnext:main", "main"]
    })
  ],
};
```

This PR is a breaking change as now unqualified resolve requests are handled by rollup core instead of pnp.

Closes #2 , closes #4 